### PR TITLE
Add type hint with PHPDoc comment annotation style

### DIFF
--- a/src/Pluralizer.php
+++ b/src/Pluralizer.php
@@ -36,7 +36,7 @@ class Pluralizer
     }
 
     /**
-     * Pluralize words.
+     * Pluralize the word.
      *
      * @return Word
      */
@@ -80,7 +80,7 @@ class Pluralizer
     }
 
     /**
-     * Check the word is uncountable.
+     * Check the word is uncountable, meaning there is no spelling difference between the plural and singular versions of the word.
      *
      * @return bool
      */

--- a/src/Pluralizer.php
+++ b/src/Pluralizer.php
@@ -6,10 +6,12 @@ use Doctrine\Common\Inflector\Inflector;
 
 class Pluralizer
 {
+    /** @var array */
     private $irregular = [
         'goose' => 'geese',
     ];
 
+    /** @var array */
     private $uncountable = [
         'audio',
         'education',
@@ -18,13 +20,26 @@ class Pluralizer
         'mathematics',
     ];
 
+    /** @var Word|null */
     private $word;
 
+    /**
+     * Constructor.
+     *
+     * @param Word $word
+     *
+     * @return void
+     */
     public function __construct(Word $word)
     {
         $this->word = $word;
     }
 
+    /**
+     * Pluralize words.
+     *
+     * @return Word
+     */
     public function pluralize()
     {
         if ($this->isUncountable()) {
@@ -42,6 +57,11 @@ class Pluralizer
         return new Word($plural);
     }
 
+    /**
+     * Singularize the word.
+     *
+     * @return Word
+     */
     public function singularize()
     {
         if ($this->isUncountable()) {
@@ -59,6 +79,11 @@ class Pluralizer
         return new Word($singular);
     }
 
+    /**
+     * Check the word is uncountable.
+     *
+     * @return bool
+     */
     private function isUncountable()
     {
         return in_array($this->word, $this->uncountable);

--- a/src/Word.php
+++ b/src/Word.php
@@ -7,27 +7,54 @@ use rapidweb\RWFileCache\RWFileCache;
 
 class Word
 {
+    /** @var string|null */
     private $word;
+
+    /** @var RWFileCache|null */
     private $cache;
 
+    /**
+     * Constructor.
+     *
+     * @param string $word
+     *
+     * @return void
+     */
     public function __construct(string $word)
     {
         $this->word = $word;
         $this->setupCache();
     }
 
+    /**
+     * Convert class instance to string.
+     *
+     * @return string
+     */
     public function __toString()
     {
         return $this->word;
     }
 
+    /**
+     * Set up cache.
+     *
+     * @return void
+     */
     private function setupCache()
     {
         $this->cache = new RWFileCache();
         $this->cache->changeConfig(['cacheDirectory' => '/tmp/php-word-info-cache/']);
     }
 
-    public function rhymes($halfRhymes = false)
+    /**
+     * Add the rhyme in word.
+     *
+     * @param bool $halfRhymes
+     *
+     * @return mixed
+     */
+    public function rhymes(bool $halfRhymes = false)
     {
         $cacheKey = $this->word.'.rhymes';
 
@@ -65,31 +92,61 @@ class Word
         return $rhymes;
     }
 
+    /**
+     * Let word be half rhymes.
+     *
+     * @return mixed
+     */
     public function halfRhymes()
     {
         return $this->rhymes(true);
     }
 
+    /**
+     * Syllables word.
+     *
+     * @return int
+     */
     public function syllables()
     {
         return Syllables::syllableCount($this->word);
     }
 
+    /**
+     * Plural word.
+     *
+     * @return string
+     */
     public function plural()
     {
         return (new Pluralizer($this))->pluralize();
     }
 
+    /**
+     * Singular word.
+     *
+     * @return string
+     */
     public function singular()
     {
         return (new Pluralizer($this))->singularize();
     }
 
+    /**
+     * Check the word is offensive.
+     *
+     * @return bool
+     */
     public function offensive()
     {
         return is_offensive($this->word);
     }
 
+    /**
+     * Portmanteaus word.
+     *
+     * @return mixed
+     */
     public function portmanteaus()
     {
         $cacheKey = $this->word.'.portmanteaus';


### PR DESCRIPTION
# Changed log
- Add type hint with `PHPDoc` comment annotation style.
- It's related to issue #3.